### PR TITLE
Fix weird relative paths in libraries on Mac

### DIFF
--- a/recipes/libxml2/build.sh
+++ b/recipes/libxml2/build.sh
@@ -16,5 +16,13 @@ fi
             --with-python="${PREFIX}" \
             --with-zlib="${PREFIX}"
 make
+# Correct weirdly linked library paths.
+if [[ `uname` == 'Darwin' ]];
+then
+    LIBDIR="${PREFIX}/lib"
+    LIBICUDATA="`cd ${LIBDIR} && ls libicudata.*.*.dylib`"
+    find "${SRC_DIR}/.libs" -type f | xargs -I {} install_name_tool -change "../lib/${LIBICUDATA}" "${PREFIX}/lib/${LIBICUDATA}" {} || true
+    find "${SRC_DIR}/python/.libs" -type f | xargs -I {} install_name_tool -change "../lib/${LIBICUDATA}" "${PREFIX}/lib/${LIBICUDATA}" {} || true
+fi
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check
 make install

--- a/recipes/libxml2/meta.yaml
+++ b/recipes/libxml2/meta.yaml
@@ -32,6 +32,8 @@ requirements:
         - zlib
 
 test:
+    imports:
+        - libxml2
     files:
         - test.xml
     commands:


### PR DESCRIPTION
Related: https://github.com/conda-forge/staged-recipes/pull/266

This PR changes the paths for the libraries on Mac to address a weird issue where some libraries linked against `../lib/libicudata.56.1.dylib`. Further, `conda-build` failed to change these library paths to use the `@rpath` syntax. This patch expands those library paths to include the full prefix. As a result, `conda-build` is able to recognize this and change them to use the `@rpath` syntax instead. Additionally, we add a Python import test to make sure `libxml2` can be imported correctly.
